### PR TITLE
Settings, PlantFinder and colors changes

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.terratutor.app">
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <application
         android:label="terra_tutor"
         android:name="${applicationName}"

--- a/lib/Global_Elements/colors.dart
+++ b/lib/Global_Elements/colors.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
-class AppColors
-{
+class AppColors {
   // Background color
   static const Color primaryColor = Color.fromARGB(255, 226, 217, 199);
 
@@ -12,7 +11,8 @@ class AppColors
   static const Color navBar = Color.fromARGB(255, 194, 209, 97);
 
   // Menu icon highlight box color
-  static const Color menuIconHighLight = Color.fromARGB(255, 255, 255, 255); // Transparency will be ajusted upon icon tsting
+  static const Color menuIconHighLight = Color.fromARGB(
+      255, 255, 255, 255); // Transparency will be ajusted upon icon tsting
 
   // Menu icon colors
   static const Color menuIconClicked = Color.fromARGB(255, 0, 0, 0);
@@ -20,6 +20,121 @@ class AppColors
 
   // Font color
   static const Color fontColor = Color.fromARGB(255, 0, 0, 0);
+
+  // Delete button color
+  static const Color deleteButton = Color.fromARGB(127, 255, 0, 0);
+}
+
+class AppColorsAlternativeTropicalGarden {
+  // Background color
+  static const Color primaryColor = Color.fromARGB(255, 226, 217, 199);
+
+  // Widget tile color
+  static const Color uiTile = Color(0XFF7D9E96);
+
+  // Top and bottom Nav bar color
+  static const Color navBar = Color(0xFFADC2AF);
+
+  // Menu icon highlight box color
+  static const Color menuIconHighLight = Color(0XFF7D9E96);
+  // Menu icon colors
+  static const Color menuIconClicked = Color(0XFF000000);
+  static const Color menuIconUnclicked = Color.fromARGB(255, 127, 127, 127);
+
+  // Font color
+  static const Color fontColor = Color(0XFF000000);
+
+  // Delete button color
+  static const Color deleteButton = Color.fromARGB(127, 255, 0, 0);
+}
+
+class AppColorsAlternativeWoodlandForest {
+  // Background color
+  static const Color primaryColor = Color(0xFFADC2AF);
+
+  // Widget tile color
+  static const Color uiTile = Color(0XFF7D9E96);
+
+  // Top and bottom Nav bar color
+  static const Color navBar = Color(0xFFADC2AF);
+
+  // Menu icon highlight box color
+  static const Color menuIconHighLight = Color(0XFF7D9E96);
+  // Menu icon colors
+  static const Color menuIconClicked = Color(0XFF000000);
+  static const Color menuIconUnclicked = Color.fromARGB(255, 127, 127, 127);
+
+  // Font color
+  static const Color fontColor = Color(0XFF000000);
+
+  // Delete button color
+  static const Color deleteButton = Color.fromARGB(127, 255, 0, 0);
+}
+
+class AppColorsAlternativeHighDesert {
+  // Background color
+  static const Color primaryColor = Color(0xFFADC2AF);
+
+  // Widget tile color
+  static const Color uiTile = Color(0XFF7D9E96);
+
+  // Top and bottom Nav bar color
+  static const Color navBar = Color(0xFFADC2AF);
+
+  // Menu icon highlight box color
+  static const Color menuIconHighLight = Color(0XFF7D9E96);
+  // Menu icon colors
+  static const Color menuIconClicked = Color(0XFF000000);
+  static const Color menuIconUnclicked = Color.fromARGB(255, 127, 127, 127);
+
+  // Font color
+  static const Color fontColor = Color(0XFF000000);
+
+  // Delete button color
+  static const Color deleteButton = Color.fromARGB(127, 255, 0, 0);
+}
+
+class AppColorsAlternativeRedwoodForest {
+  // Background color
+  static const Color primaryColor = Color(0xFFADC2AF);
+
+  // Widget tile color
+  static const Color uiTile = Color(0XFF7D9E96);
+
+  // Top and bottom Nav bar color
+  static const Color navBar = Color(0xFFADC2AF);
+
+  // Menu icon highlight box color
+  static const Color menuIconHighLight = Color(0XFF7D9E96);
+  // Menu icon colors
+  static const Color menuIconClicked = Color(0XFF000000);
+  static const Color menuIconUnclicked = Color.fromARGB(255, 127, 127, 127);
+
+  // Font color
+  static const Color fontColor = Color(0XFF000000);
+
+  // Delete button color
+  static const Color deleteButton = Color.fromARGB(127, 255, 0, 0);
+}
+
+class AppColorsAlternativeArcticGarden {
+  // Background color
+  static const Color primaryColor = Color(0xFFADC2AF);
+
+  // Widget tile color
+  static const Color uiTile = Color(0XFF7D9E96);
+
+  // Top and bottom Nav bar color
+  static const Color navBar = Color(0xFFADC2AF);
+
+  // Menu icon highlight box color
+  static const Color menuIconHighLight = Color(0XFF7D9E96);
+  // Menu icon colors
+  static const Color menuIconClicked = Color(0XFF000000);
+  static const Color menuIconUnclicked = Color.fromARGB(255, 127, 127, 127);
+
+  // Font color
+  static const Color fontColor = Color(0XFF000000);
 
   // Delete button color
   static const Color deleteButton = Color.fromARGB(127, 255, 0, 0);

--- a/lib/Screens/plant_finder_screen.dart
+++ b/lib/Screens/plant_finder_screen.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:retry/retry.dart';
+import 'dart:async';
+import 'dart:math';
 import '/Global_Elements/colors.dart';
 import '/Global_Elements/top_navigation.dart';
-import '/Global_Elements/bottom_navigation.dart'; // Ensure this import points to the correct location
+import '/Global_Elements/bottom_navigation.dart';
 
 class PlantFinderScreen extends StatefulWidget {
   const PlantFinderScreen({super.key});
@@ -12,14 +18,22 @@ class PlantFinderScreen extends StatefulWidget {
 
 class _PlantFinderPageState extends State<PlantFinderScreen> {
   int _selectedIndex = 2; // Index for BottomNavigationBar
-
+  //Plant list
+  List plants = [];
+  int currentPlantIndex = 0;
   // State default variables for plant name, description, and image
   String plantName = 'Rose';
   String plantDescription =
       'Roses are one of the oldest flowers on Earth. Fossil evidence suggests that roses are at least 35 million years old!';
   String plantImage = 'lib/Assets/images/rose_placeholder.jpg';
 
-  void _onItemTapped(int index) {
+  @override
+  void initState() {
+    super.initState();
+    fetchRandomPlant();
+  }
+
+  void onItemTapped(int index) {
     // Handle navigation based on selected index
     setState(() {
       _selectedIndex = index;
@@ -27,61 +41,84 @@ class _PlantFinderPageState extends State<PlantFinderScreen> {
   }
 
   void onBackButtonPressed() {
-    // Placeholder for back button functionality
-    fetchFromAPI("back");
+    if (currentPlantIndex > 0) {
+      currentPlantIndex--;
+      updatePlantFromIndex();
+    }
   }
 
   void onShuffleButtonPressed() {
-    // Placeholder for shuffle button functionality
-    fetchFromAPI("shuffle");
+    fetchRandomPlant();
   }
 
   void onForwardButtonPressed() {
-    // Placeholder for forward button functionality
-    fetchFromAPI("forward");
+    if (currentPlantIndex < plants.length - 1) {
+      currentPlantIndex++;
+      updatePlantFromIndex();
+    }
   }
 
   void onCameraButtonPressed() {
     // Placeholder for camera button functionality
   }
-  void fetchFromAPI(String type) {
-    setState(() {
-      if (type == "shuffle") {
-        //API Calls here for random plant
-        updatePlant(
-          'Random Plant', // Example name
-          'Description of a random plant.', // Example description
-          'lib/Assets/images/random_plant.jpg', // Example image path
-        );
-      } else if (type == "back") {
-        //API Calls here for previous plant
-        updatePlant(
-          'Previous Plant', // Example name
-          'Description of the previous plant.', // Example description
-          'lib/Assets/images/previous_plant.jpg', // Example image path
-        );
-      } else if (type == "forward") {
-        //API Calls here for random plant
-        updatePlant(
-          'Next Plant', // Example name
-          'Description of the next plant.', // Example description
-          'lib/Assets/images/next_plant.jpg', // Example image path
-        );
+
+  Future<void> fetchRandomPlant() async {
+    final String? apiKey = dotenv.env['TREFLE_API_KEY'];
+    if (apiKey == null) {
+      print('Error: API key is missing');
+      return;
+    }
+
+    // Use a random page number to get random results from the API
+    final randomPage = Random().nextInt(100) + 1;
+    final String apiUrl =
+        'https://trefle.io/api/v1/plants?token=$apiKey&page=$randomPage';
+
+    try {
+      print('Fetching data from API...');
+      final response = await retry(
+        () => http.get(Uri.parse(apiUrl)).timeout(Duration(seconds: 5)),
+        retryIf: (e) => e is http.ClientException || e is TimeoutException,
+        maxAttempts: 3,
+      );
+
+      if (response.statusCode == 200) {
+        print('API call successful');
+        final data = json.decode(response.body);
+        setState(() {
+          plants = data['data'] as List;
+          plants.shuffle();
+          currentPlantIndex = 0;
+          updatePlantFromIndex();
+        });
+      } else {
+        print('Failed to load plant data: ${response.statusCode}');
       }
-    });
+    } catch (e) {
+      print('Error fetching plant data: $e');
+    }
   }
 
-  void updatePlant(String name, String description, String image) {
-    setState(() {
-      plantName = name;
-      plantDescription = description;
-      plantImage = image;
-    });
+  void updatePlantFromIndex() {
+    if (plants.isNotEmpty) {
+      final selectedPlant = plants[currentPlantIndex];
+      String imageUrl = selectedPlant['image_url'] ?? '';
+      if (imageUrl.isEmpty || !Uri.parse(imageUrl).isAbsolute) {
+        imageUrl = 'lib/Assets/images/rose_placeholder.jpg'; // Fallback image
+      }
+
+      setState(() {
+        plantName = selectedPlant['common_name'] ?? 'Unknown Plant';
+        plantDescription =
+            selectedPlant['scientific_name'] ?? 'No description available';
+        plantImage = imageUrl;
+      });
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    //Get current screen size for later
+    // Get current screen size for later
     final screenWidth = MediaQuery.of(context).size.width;
     final screenHeight = MediaQuery.of(context).size.height;
 
@@ -150,7 +187,6 @@ class _PlantFinderPageState extends State<PlantFinderScreen> {
                     color: AppColors.uiTile,
                   ),
                   child: IconButton(
-                    //TODO: Switch out Icons.arrow_back with custom image.
                     icon:
                         Image.asset('lib/Assets/images/reverse_arrow_100.png'),
                     onPressed: onBackButtonPressed,
@@ -166,7 +202,6 @@ class _PlantFinderPageState extends State<PlantFinderScreen> {
                     color: AppColors.uiTile,
                   ),
                   child: IconButton(
-                    //TODO: Switch out Icons.shuffle with custom image.
                     icon: Image.asset('lib/Assets/images/shuffle_final.png'),
                     onPressed: onShuffleButtonPressed,
                   ),
@@ -181,7 +216,6 @@ class _PlantFinderPageState extends State<PlantFinderScreen> {
                     color: AppColors.uiTile,
                   ),
                   child: IconButton(
-                    //TODO: Switch out Icons.forward with custom image.
                     icon:
                         Image.asset('lib/Assets/images/forward_arrow_100.png'),
                     onPressed: onForwardButtonPressed,
@@ -216,10 +250,22 @@ class _PlantFinderPageState extends State<PlantFinderScreen> {
                                 ),
                                 child: ClipRRect(
                                   borderRadius: BorderRadius.circular(20.0),
-                                  child: Image.asset(
-                                    plantImage,
-                                    fit: BoxFit.cover,
-                                  ),
+                                  child: plantImage.startsWith('http')
+                                      ? Image.network(
+                                          plantImage,
+                                          fit: BoxFit.cover,
+                                          errorBuilder:
+                                              (context, error, stackTrace) {
+                                            return Image.asset(
+                                              'lib/Assets/images/default_plant.jpg',
+                                              fit: BoxFit.cover,
+                                            );
+                                          },
+                                        )
+                                      : Image.asset(
+                                          plantImage,
+                                          fit: BoxFit.cover,
+                                        ),
                                 ),
                               ),
                               const Positioned(
@@ -238,19 +284,16 @@ class _PlantFinderPageState extends State<PlantFinderScreen> {
                         Text(
                           plantName,
                           style: const TextStyle(
-                            fontSize: 24.0,
-                            fontWeight: FontWeight.bold,
-                            color: AppColors.fontColor,
-                          ),
+                              fontSize: 24.0,
+                              fontWeight: FontWeight.bold,
+                              color: AppColors.fontColor),
                         ),
                         const SizedBox(height: 8.0),
                         Text(
                           plantDescription,
                           textAlign: TextAlign.center,
                           style: const TextStyle(
-                            fontSize: 16.0,
-                            color: AppColors.fontColor,
-                          ),
+                              fontSize: 16.0, color: AppColors.fontColor),
                         ),
                       ],
                     ),
@@ -263,7 +306,7 @@ class _PlantFinderPageState extends State<PlantFinderScreen> {
       ),
       bottomNavigationBar: BottomNavigation(
         selectedIndex: _selectedIndex,
-        onTap: _onItemTapped,
+        onTap: onItemTapped,
       ),
     );
   }

--- a/lib/Screens/settings_page.dart
+++ b/lib/Screens/settings_page.dart
@@ -1,21 +1,100 @@
+// ignore_for_file: unrelated_type_equality_checks
+
 import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import '../Global_Elements/colors.dart';
 import '/Screens/profile_page.dart';
 import '/Global_Elements/top_navigation.dart';
+import 'entrance_screen.dart'; // Make sure to import your entrance screen
 
-class SettingsPage extends StatelessWidget {
+class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
+
+  @override
+  _SettingsPageState createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  String selectedTheme = 'Default';
+
+  void setSelectedTheme(String theme) {
+    setState(() {
+      selectedTheme = theme;
+    });
+    themeSelectionFunctionality(theme);
+  }
+
+  void themeSelectionFunctionality(String theme) {
+    switch (theme) {
+      case 'Default':
+        // Functionality for Default theme
+        print('Default theme selected');
+        break;
+      case 'Tropical Garden':
+        // Functionality for Tropical Garden theme
+        print('Tropical Garden theme selected');
+        break;
+      case 'Woodland Forest':
+        // Functionality for Woodland Forest theme
+        print('Woodland Forest theme selected');
+        break;
+      case 'High Desert':
+        // Functionality for High Desert theme
+        print('High Desert theme selected');
+        break;
+      case 'Redwood Forest':
+        // Functionality for Redwood Forest theme
+        print('Redwood Forest theme selected');
+        break;
+      case 'Arctic Garden':
+        // Functionality for Arctic Garden theme
+        print('Arctic Garden theme selected');
+        break;
+      default:
+        print('Unknown theme selected');
+    }
+  }
+
+  //When theme is selected this builds the output.
+  Widget buildThemeOption(String theme) {
+    return GestureDetector(
+      onTap: () => setSelectedTheme(theme),
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (selectedTheme == theme)
+              const Icon(
+                Icons.check,
+                color: Colors.black,
+              ),
+            const SizedBox(width: 8.0),
+            Text(
+              theme,
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: selectedTheme == theme
+                    ? FontWeight.bold
+                    : FontWeight.normal,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const TopNavigation(
-        title: 'Settings', // Pass the required title here
+        title: 'Settings',
         backButton: true,
         showMenuIcon: false,
       ),
       body: Container(
-        color: AppColors.primaryColor, // Change color after color from palette is decided
+        color: AppColors.primaryColor,
         child: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -25,31 +104,26 @@ class SettingsPage extends StatelessWidget {
                 onPressed: () {
                   Navigator.push(
                     context,
-                    MaterialPageRoute(builder: (context) => const ProfilePage()),
+                    MaterialPageRoute(
+                        builder: (context) => const ProfilePage()),
                   );
                 },
                 child: const Text(
                   'Profile',
                   textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 30, fontWeight: FontWeight.bold, color: Colors.black),
+                  style: TextStyle(
+                      fontSize: 30,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.black),
                 ),
               ),
-              // ListTile(
-              //   title: Text(
-              //     'Profile',
-              //     textAlign: TextAlign.center,
-              //     style: TextStyle(fontSize: 30, fontWeight: FontWeight.bold),
-              //   ),
-              //   onTap: null, // Implement navigation or function here
-              // ),
-              // TODO: convert the rest of these to be text buttons
               const ListTile(
                 title: Text(
                   'Notifications',
                   textAlign: TextAlign.center,
                   style: TextStyle(fontSize: 30, fontWeight: FontWeight.bold),
                 ),
-                onTap: null, // Implement navigation or function here
+                onTap: null, // Implement notification functionality.
               ),
               const ListTile(
                 title: Text(
@@ -57,54 +131,34 @@ class SettingsPage extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: TextStyle(fontSize: 30, fontWeight: FontWeight.bold),
                 ),
-                onTap: null, // Implement navigation or function here
+                onTap: null,
               ),
-              const Padding(
-                padding: EdgeInsets.all(8.0),
-                child: Text(
-                  'Default',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 20),
+              const SizedBox(height: 16),
+              buildThemeOption('Default'),
+              buildThemeOption('Tropical Garden'),
+              buildThemeOption('Woodland Forest'),
+              buildThemeOption('High Desert'),
+              buildThemeOption('Redwood Forest'),
+              buildThemeOption('Arctic Garden'),
+              const SizedBox(height: 32),
+              TextButton(
+                style: TextButton.styleFrom(
+                  backgroundColor: AppColors.deleteButton,
+                  foregroundColor: Colors.white,
+                  side: const BorderSide(color: Colors.black),
+                  fixedSize: const Size(100, 25),
                 ),
-              ),
-              const Padding(
-                padding: EdgeInsets.all(8.0),
-                child: Text(
-                  'Tropical Garden',
+                onPressed: () async {
+                  await FirebaseAuth.instance.signOut();
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => const EntranceScreen()),
+                  );
+                },
+                child: const Text(
+                  'Logout',
                   textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 20),
-                ),
-              ),
-              const Padding(
-                padding: EdgeInsets.all(8.0),
-                child: Text(
-                  'Woodland Forest',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 20),
-                ),
-              ),
-              const Padding(
-                padding: EdgeInsets.all(8.0),
-                child: Text(
-                  'High Desert',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 20),
-                ),
-              ),
-              const Padding(
-                padding: EdgeInsets.all(8.0),
-                child: Text(
-                  'Redwood Forest',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 20),
-                ),
-              ),
-              const Padding(
-                padding: EdgeInsets.all(8.0),
-                child: Text(
-                  'Arctic Garden',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 20),
                 ),
               ),
             ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,17 @@
 import 'package:flutter/material.dart';
-// ignore: unnecessary_import
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
 import 'package:flutter/rendering.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:terra_tutor/Screens/splash_screen.dart';
+import 'package:terra_tutor/Screens/settings_page.dart';
 import 'package:terra_tutor/Screens/plant_finder_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  //Loads env file for trefle api key
+  await dotenv.load(fileName: ".env");
   await Firebase.initializeApp();
   runApp(const MyApp());
 }
@@ -23,7 +28,6 @@ class MyApp extends StatelessWidget {
         useMaterial3: true,
       ),
       home: const SplashScreen(),
-      // home: const SplashScreen(), //Sends user to splash screen first.
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -312,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  retry:
+    dependency: "direct main"
+    description:
+      name: retry
+      sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   firebase_auth: ^4.6.1
   http: ^1.0.0
   flutter_dotenv: ^5.0.2
+  retry: ^3.0.0
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
![plantfromapi2](https://github.com/Brandon-T-Yates/terra_tutor/assets/3190589/1589b300-aebb-4b14-ad67-61e980114f14)
![settingsScreen1](https://github.com/Brandon-T-Yates/terra_tutor/assets/3190589/70528ce4-1e8e-4535-9354-56ffc1ce124f)
![week1image](https://github.com/Brandon-T-Yates/terra_tutor/assets/3190589/067f7590-c90e-4c6f-89c6-cb5c3e2a7692)

1.	Added new “Themes” framework for the alternative themes. Check marks and bolded when a theme is chosen.
2.	Setup the code to switch themes when Text buttons are pressed.
3.	Added logout button and functionality with firebase

Plant finder:
1. Connected this page to the api.
2. Calls api for a random plant.
3. Parses plant data
4. Updates Name, Description, and scientific name on the page
5. Made a list that stores current plant index.
6. Finds next plant on list and saves previous plant to return to it when forward or shuffle is pressed.

Colors:
Just added blank Themes to add colors into for switching themes functionality in the future.
